### PR TITLE
Fixed hardcoded myshop name to app_name variable in variant_admin

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/admin.py
@@ -184,7 +184,7 @@ class SmartPhoneInline(admin.TabularInline):
         return readonly_fields
 
     def variant_admin(self, obj):
-        link = reverse('admin:myshop_smartphonevariant_change', args=(obj.id,)), _("Edit Variant")
+        link = reverse('admin:{{ cookiecutter.app_name }}_smartphonevariant_change', args=(obj.id,)), _("Edit Variant")
         return format_html(
             '<span class="object-tools"><a href="#" onclick="shopShowAdminPopup(\'{0}\', \'Edit Variant\');" class="viewsitelink">{1}</a></span>',
             *link)


### PR DESCRIPTION
Hardcoded myshop name caused an exception in admin for smartphone model if demo is generated with custom app_name (not myshop).


