### PR TITLE
Allow user to select Python version

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -38,5 +38,6 @@
     "inventory",
     "n"
   ],
-  "debug": "y"
+  "debug": "y",
+  "python_version": "3.9"
 }

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -67,7 +67,7 @@ factory-boy = "*"
 pytest-factoryboy = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "{{ cookiecutter.python_version }}"
 
 [pipenv]
 allow_prereleases = true


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)
Update the cookiecutter file to allow the user select the Python version required in the Pipfile.

## Rationale

[//]: # (Why does the project need that?)

Because it would make the installation process smoother without any alerts from Pip stating that the Python version is not compatible.