### PR TITLE
fix: correction of the application name variable of the generated template

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/templates/{{ cookiecutter.app_name }}/search/indexes/smartphonemodel.txt
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/templates/{{ cookiecutter.app_name }}/search/indexes/smartphonemodel.txt
@@ -1,4 +1,4 @@
-{{ '{%' }} include "myshop/search/indexes/product.txt" {{ '%}' }}
+{{ '{%' }} include "{{ cookiecutter.app_name }}/search/indexes/product.txt" {{ '%}' }}
 {% raw %}{{ product.description }}
 {{ product.operating_system }}{% for variant in product.get_product_variants %}
 {{ variant.storage}}GB{% endfor %}


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)


When generating the demo application, the variable remains set to the word "myshop" and does not configure the name of the incoming application, which is a variable.


## Rationale

[//]: # (Why does the project need that?)

Generates an error when generating the indexes.
the solution replace "myshop" with the variable:
{{cookiecutter.app_name }}


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


